### PR TITLE
Adding snippet to remove all inputs without matching labels

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -4,73 +4,76 @@ var contextMenus = {};
 contextMenus.WebPage = chrome.contextMenus.create(
   { "title": "Web Page", "type": "normal", contexts: ["all"] });
 
-  contextMenus.Accessibility = chrome.contextMenus.create(
-    { "title": "Accessibility", "type": "normal", contexts: ["all"], "parentId": contextMenus.WebPage });
-  contextMenus.AccessibilityAltReplace = chrome.contextMenus.create(
-    { "title": "Remove Images Without Alt Tags", "type": "normal", contexts: ["all"], "parentId": contextMenus.Accessibility });
-  contextMenus.AccessibilityPageFlow = chrome.contextMenus.create(
-    { "title": "Visualise Tab Flow", "type": "normal", contexts: ["all"], "parentId": contextMenus.Accessibility });
-  
-  contextMenus.Validation = chrome.contextMenus.create(
-    { "title": "Validation", "type": "normal", contexts: ["all"], "parentId": contextMenus.WebPage });
-  contextMenus.ValidationRemoveMaxLength = chrome.contextMenus.create(
-    { "title": "Remove Max Length Attributes", "type": "normal", contexts: ["all"], "parentId": contextMenus.Validation });
-  contextMenus.ValidationRemoveRequired = chrome.contextMenus.create(
-    { "title": "Remove Required Field Attributes", "type": "normal", contexts: ["all"], "parentId": contextMenus.Validation });
-  contextMenus.ValidationRemovePasteRestriction = chrome.contextMenus.create(
-    { "title": "Remove Paste Restrictions", "type": "normal", contexts: ["all"], "parentId": contextMenus.Validation });
+contextMenus.Accessibility = chrome.contextMenus.create(
+  { "title": "Accessibility", "type": "normal", contexts: ["all"], "parentId": contextMenus.WebPage });
+contextMenus.AccessibilityAltReplace = chrome.contextMenus.create(
+  { "title": "Remove Images Without Alt Tags", "type": "normal", contexts: ["all"], "parentId": contextMenus.Accessibility });
+contextMenus.AccessibilityPageFlow = chrome.contextMenus.create(
+  { "title": "Visualise Tab Flow", "type": "normal", contexts: ["all"], "parentId": contextMenus.Accessibility });
+contextMenus.AccessibilityRemoveInputsNoLabel = chrome.contextMenus.create(
+  { "title": "Remove Inputs Without Labels", "type": "normal", contexts: ["all"], "parentId": contextMenus.Accessibility });
+
+contextMenus.Validation = chrome.contextMenus.create(
+  { "title": "Validation", "type": "normal", contexts: ["all"], "parentId": contextMenus.WebPage });
+contextMenus.ValidationRemoveMaxLength = chrome.contextMenus.create(
+  { "title": "Remove Max Length Attributes", "type": "normal", contexts: ["all"], "parentId": contextMenus.Validation });
+contextMenus.ValidationRemoveRequired = chrome.contextMenus.create(
+  { "title": "Remove Required Field Attributes", "type": "normal", contexts: ["all"], "parentId": contextMenus.Validation });
+contextMenus.ValidationRemovePasteRestriction = chrome.contextMenus.create(
+  { "title": "Remove Paste Restrictions", "type": "normal", contexts: ["all"], "parentId": contextMenus.Validation });
 
 chrome.contextMenus.onClicked.addListener(contextMenuClickHandler);
 
-function contextMenuClickHandler(info, tab){
+function contextMenuClickHandler(info, tab) {
 
   // TODO: configure everything in here to avoid creating menus above, have something parse array to create menus
   var menuActions = [
     { id: contextMenus.AccessibilityAltReplace, file: "js/web/accessibility/removeImagesWithoutAltTags.js", instant: false },
     { id: contextMenus.AccessibilityPageFlow, file: "js/web/accessibility/visualiseTabFlow.js", instant: false },
+    { id: contextMenus.AccessibilityRemoveInputsNoLabel, file: "js/web/accessibility/removeInputsWithoutLabel.js", instant: false },
     { id: contextMenus.ValidationRemoveMaxLength, file: "js/web/validation/removeMaxLength.js", instant: false },
     { id: contextMenus.ValidationRemoveRequired, file: "js/web/validation/removeRequired.js", instant: false },
     { id: contextMenus.ValidationRemovePasteRestriction, file: "js/web/validation/removePasteRestrictions.js", instant: false },
-      ];
+  ];
 
-    var actionToDo;
+  var actionToDo;
 
-    for (var actionindex = 0; actionindex < menuActions.length; actionindex++) {
-      if(menuActions[actionindex].id===info.menuItemId){
-          actionToDo = menuActions[actionindex];
-          break;
-      }
+  for (var actionindex = 0; actionindex < menuActions.length; actionindex++) {
+    if (menuActions[actionindex].id === info.menuItemId) {
+      actionToDo = menuActions[actionindex];
+      break;
     }
+  }
 
-    var errorHandler = function() {
-      if (chrome.runtime.lastError) {
-        console.error(chrome.runtime.lastError.message);
-      }
-    };
-
-    // file reading is async https://stackoverflow.com/questions/4100927/chrome-filereader
-    function sendFileContentsAsMessage(filecontents){
-        chrome.tabs.sendMessage(tab.id, {type: "display", messageContents: "Script to Run:\n"});
-        chrome.tabs.sendMessage(tab.id, {type: "display", messageContents: filecontents});
+  var errorHandler = function () {
+    if (chrome.runtime.lastError) {
+      console.error(chrome.runtime.lastError.message);
     }
+  };
 
-    function sendFileContentsAsBookmarklet(filecontents){
-        var bookmarklet = "javascript:(function(){" + encodeURI(filecontents) + "})()";
-        chrome.tabs.sendMessage(tab.id, {type: "display", messageContents: "As Bookmarklet:\n"});
-        chrome.tabs.sendMessage(tab.id, {type: "display", messageContents: bookmarklet});
-    }
+  // file reading is async https://stackoverflow.com/questions/4100927/chrome-filereader
+  function sendFileContentsAsMessage(filecontents) {
+    chrome.tabs.sendMessage(tab.id, { type: "display", messageContents: "Script to Run:\n" });
+    chrome.tabs.sendMessage(tab.id, { type: "display", messageContents: filecontents });
+  }
+
+  function sendFileContentsAsBookmarklet(filecontents) {
+    var bookmarklet = "javascript:(function(){" + encodeURI(filecontents) + "})()";
+    chrome.tabs.sendMessage(tab.id, { type: "display", messageContents: "As Bookmarklet:\n" });
+    chrome.tabs.sendMessage(tab.id, { type: "display", messageContents: bookmarklet });
+  }
 
 
   // cannot just execute script if the bot wants to access local variables
   // https://stackoverflow.com/questions/16784553/chrome-extension-throws-not-defined-on-defined-variable
 
-  if(actionToDo.instant){
-    chrome.tabs.executeScript(null, {file: actionToDo.file}, errorHandler);
-  }else{
+  if (actionToDo.instant) {
+    chrome.tabs.executeScript(null, { file: actionToDo.file }, errorHandler);
+  } else {
     // inject script and send a message to create script tag - not as good though
-     chrome.tabs.executeScript(tab.id, {file: 'js/contentscript.js'}, function() {
+    chrome.tabs.executeScript(tab.id, { file: 'js/contentscript.js' }, function () {
       // do it
-      chrome.tabs.sendMessage(tab.id, {type: "execfile", filename:actionToDo.file});
+      chrome.tabs.sendMessage(tab.id, { type: "execfile", filename: actionToDo.file });
       // display it
       getFileContents(actionToDo.file, errorHandler, sendFileContentsAsMessage);
       getFileContents(actionToDo.file, errorHandler, sendFileContentsAsBookmarklet);
@@ -79,12 +82,12 @@ function contextMenuClickHandler(info, tab){
 
 
   // read a file https://stackoverflow.com/questions/28858027/how-to-read-file-from-chrome-extension
-  function getFileContents(filename, errorHandler, callback){
-    chrome.runtime.getPackageDirectoryEntry(function(root) {
-      root.getFile(filename, {}, function(fileEntry) {
-        fileEntry.file(function(file) {
+  function getFileContents(filename, errorHandler, callback) {
+    chrome.runtime.getPackageDirectoryEntry(function (root) {
+      root.getFile(filename, {}, function (fileEntry) {
+        fileEntry.file(function (file) {
           var reader = new FileReader();
-          reader.onloadend = function(e) {
+          reader.onloadend = function (e) {
             // contents are in .result
             callback(this.result);
           };
@@ -92,5 +95,5 @@ function contextMenuClickHandler(info, tab){
         }, errorHandler);
       }, errorHandler);
     });
- }
+  }
 }

--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -8,10 +8,10 @@ contextMenus.Accessibility = chrome.contextMenus.create(
   { "title": "Accessibility", "type": "normal", contexts: ["all"], "parentId": contextMenus.WebPage });
 contextMenus.AccessibilityAltReplace = chrome.contextMenus.create(
   { "title": "Remove Images Without Alt Tags", "type": "normal", contexts: ["all"], "parentId": contextMenus.Accessibility });
-contextMenus.AccessibilityPageFlow = chrome.contextMenus.create(
-  { "title": "Visualise Tab Flow", "type": "normal", contexts: ["all"], "parentId": contextMenus.Accessibility });
 contextMenus.AccessibilityRemoveInputsNoLabel = chrome.contextMenus.create(
   { "title": "Remove Inputs Without Labels", "type": "normal", contexts: ["all"], "parentId": contextMenus.Accessibility });
+  contextMenus.AccessibilityPageFlow = chrome.contextMenus.create(
+    { "title": "Visualise Tab Flow", "type": "normal", contexts: ["all"], "parentId": contextMenus.Accessibility });
 
 contextMenus.Validation = chrome.contextMenus.create(
   { "title": "Validation", "type": "normal", contexts: ["all"], "parentId": contextMenus.WebPage });

--- a/extension/js/web/accessibility/removeInputsWithoutLabel.js
+++ b/extension/js/web/accessibility/removeInputsWithoutLabel.js
@@ -2,14 +2,13 @@ var inputs = document.querySelectorAll('input');
 var labels = document.querySelectorAll('label');
 
 for (var currentInput = 0; currentInput < inputs.length; currentInput++) {
-
     var inputHasLabel = false;
-  for (var currentLabel = 0; currentLabel < labels.length; currentLabel++) {
-    if(labels[currentLabel].htmlFor == inputs[currentInput].id) {
-      inputHasLabel = true;
+    for (var currentLabel = 0; currentLabel < labels.length; currentLabel++) {
+        if (labels[currentLabel].htmlFor == inputs[currentInput].id) {
+            inputHasLabel = true;
+        }
     }
-  }
-  if(inputHasLabel == false) {
-    inputs[currentInput].style.display = 'none';
-  }
+    if (inputHasLabel == false) {
+        inputs[currentInput].style.display = 'none';
+    }
 }

--- a/extension/js/web/accessibility/removeInputsWithoutLabel.js
+++ b/extension/js/web/accessibility/removeInputsWithoutLabel.js
@@ -1,0 +1,15 @@
+var inputs = document.querySelectorAll('input');
+var labels = document.querySelectorAll('label');
+
+for (var currentInput = 0; currentInput < inputs.length; currentInput++) {
+
+    var inputHasLabel = false;
+  for (var currentLabel = 0; currentLabel < labels.length; currentLabel++) {
+    if(labels[currentLabel].htmlFor == inputs[currentInput].id) {
+      inputHasLabel = true;
+    }
+  }
+  if(inputHasLabel == false) {
+    inputs[currentInput].style.display = 'none';
+  }
+}


### PR DESCRIPTION
Accessibility snippet added which hides all inputs where it's id does not exist as a for attribute for a label. Guideline reference: https://www.w3.org/WAI/tutorials/forms/labels/